### PR TITLE
Update README.md to include required webkit-gtk 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Sabayon welcome screen
 * gtk
 * python-gobject
 * python-simplejson
-
+* pywebkitgtk

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Sabayon welcome screen
 * gtk
 * python-gobject
 * python-simplejson
-* pywebkitgtk
+* webkit-gtk 2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sabayon-greeter
 
 Sabayon welcome screen
 
-* python3
+* python 3
 * gtk
 * python-gobject
 * python-simplejson


### PR DESCRIPTION
adding new dependency to the list. pywebkit is required for sabayon-greeter to work.